### PR TITLE
#155820624: Connect and launch details layout view

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:design:27.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.1'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,10 @@
             android:name=".DetailsActivity"
             android:label="@string/details_name"
             android:parentActivityName=".MainActivity">
+            <!-- The meta-data tag is required if you support API level 15 and lower -->
+            <meta-data
+                android:name="android.support.PARENT_ACTIVITY"
+                android:value=".MainActivity" />
         </activity>
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".DetailsActivity"
+            android:label="@string/details_name"
+            android:parentActivityName=".MainActivity">
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/andela/android/javadevelopers/DetailsActivity.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/DetailsActivity.java
@@ -1,7 +1,9 @@
 package com.andela.android.javadevelopers;
 
+import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.widget.TextView;
 
 public class DetailsActivity extends AppCompatActivity {
 
@@ -9,5 +11,18 @@ public class DetailsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+        displayProfile();
+    }
+
+    private void displayProfile() {
+        Intent intent = this.getIntent();
+        String devUsername = intent.getStringExtra("USER_NAME");
+        String devCompany = intent.getStringExtra("COMPANY");
+
+        // Capture the layout's TextView and set the string as its text
+        TextView username = findViewById(R.id.username);
+        TextView company = findViewById(R.id.company);
+        username.setText(devUsername);
+        company.setText(devCompany);
     }
 }

--- a/app/src/main/java/com/andela/android/javadevelopers/DetailsActivity.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/DetailsActivity.java
@@ -1,0 +1,13 @@
+package com.andela.android.javadevelopers;
+
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+
+public class DetailsActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_details);
+    }
+}

--- a/app/src/main/java/com/andela/android/javadevelopers/ListAdapter.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/ListAdapter.java
@@ -1,6 +1,7 @@
 package com.andela.android.javadevelopers;
 
 import android.content.Context;
+import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -18,6 +19,7 @@ public class ListAdapter extends RecyclerView.Adapter<ListAdapter.ViewHolder> {
 
     private List<DevelopersList> developersLists;
     private Context context;
+
 
     public ListAdapter(List<DevelopersList> developersLists, Context context) {
         this.developersLists = developersLists;
@@ -45,10 +47,22 @@ public class ListAdapter extends RecyclerView.Adapter<ListAdapter.ViewHolder> {
 }
 
     @Override
-    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        DevelopersList developersList = developersLists.get(position);
+    public void onBindViewHolder(@NonNull ViewHolder holder, final int position) {
+        final DevelopersList developersList = developersLists.get(position);
+        final String user_name = developersLists.get(position).getUsername();
+        final String company = developersLists.get(position).getWorkplace();
         holder.username.setText(developersList.getUsername());
         holder.workplace.setText(developersList.getWorkplace());
+        holder.itemView.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View view) {
+                Intent intent = new Intent(context, DetailsActivity.class);
+                intent.putExtra("USER_NAME", user_name);
+                intent.putExtra("COMPANY", company);
+                context.startActivity(intent);
+            }
+        });
 
     }
 

--- a/app/src/main/res/layout/activity_details.xml
+++ b/app/src/main/res/layout/activity_details.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="16dp">
+
+    <ImageView
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:src="@drawable/no_profile"
+        android:fitsSystemWindows="true"
+        android:id="@+id/profile_image_header"
+        android:scaleType="centerCrop"
+        android:contentDescription="@string/profile_image_description"
+    />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/header_username"
+        android:textAlignment="center"
+        android:text="@string/username_text"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:layout_marginTop="24dp"
+        android:fontFamily="serif"
+    />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/username"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/username"
+        android:textSize="25sp"
+        android:textAlignment="center"
+        android:fontFamily="cursive"
+        android:textStyle="bold"
+    />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/company_text"
+        android:textAlignment="center"
+        android:text="@string/company_text"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:layout_marginTop="24dp"
+        android:fontFamily="serif"
+        />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/company"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/company"
+        android:textSize="25sp"
+        android:textAlignment="center"
+        android:fontFamily="cursive"
+        android:textStyle="bold"
+        />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAlignment="center"
+        android:text="@string/github_url_text"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        android:layout_marginTop="20dp"
+        android:fontFamily="serif"
+    />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/github_url"
+        android:layout_marginLeft="16dp"
+        android:layout_marginRight="16dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="16dp"
+        android:textAlignment="center"
+        android:textSize="18sp"
+        android:text="@string/github_url"
+        android:textColor="@color/colorPrimary"
+        android:fontFamily="serif"
+    />
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,8 @@
     <string name="company">Andela Nigeria</string>
     <string name="profile_image_description">developer profile image</string>
     <string name="arrow_image_description">view details image</string>
+    <string name="github_url">github.com/chykehyman</string>
+    <string name="username_text">Username</string>
+    <string name="github_url_text">Github Link</string>
+    <string name="details_name">Profile</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?
Connects MainActivity to DetailsActivity layout view and launches details layout view

### Description of Task to be completed?

- add back action bar to AndroidManifest file
- setup and implement intent in both ListAdapter and DetailsActivity classes

### How should this be manually tested?
```
Setup android studio
Clone repo in IDE
```

Any background context you want to provide?

Nil

### What are the relevant pivotal tracker stories?

story type: feature
story Id: 155820624
story title: Launch the DetailActivity from the MainActivity

### Screenshots (if appropriate)
<img width="348" alt="screen shot 2018-03-10 at 12 26 20 am" src="https://user-images.githubusercontent.com/22524619/37234976-45d670ba-23fb-11e8-917b-86bb0bac7ec6.png">
<img width="325" alt="screen shot 2018-03-10 at 12 26 36 am" src="https://user-images.githubusercontent.com/22524619/37234978-4feb9eb8-23fb-11e8-8e72-c92f9ec680fb.png">


