### PR TITLE
#156008359: Add user profile share functionality

### DIFF
--- a/app/src/main/java/com/andela/android/javadevelopers/view/DetailsActivity.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/view/DetailsActivity.java
@@ -1,8 +1,12 @@
 package com.andela.android.javadevelopers.view;
 
 import android.content.Intent;
+import android.support.v4.app.ShareCompat;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -10,21 +14,24 @@ import com.andela.android.javadevelopers.R;
 import com.squareup.picasso.Picasso;
 
 public class DetailsActivity extends AppCompatActivity {
+    private String devProfileImage = "";
+    private String devUsername = "";
+    private String devGithubLink = "";
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_details);
+
+        Intent intent = getIntent();
+        devProfileImage = intent.getStringExtra("PROFILE_IMAGE");
+        devUsername = intent.getStringExtra("USER_NAME");
+        devGithubLink = intent.getStringExtra("GITHUB_LINK");
+
         displayProfile();
     }
 
     private void displayProfile() {
-        Intent intent = this.getIntent();
-
-        String devProfileImage = intent.getStringExtra("PROFILE_IMAGE");
-        String devUsername = intent.getStringExtra("USER_NAME");
-        String devGithubLink = intent.getStringExtra("GITHUB_LINK");
-
         ImageView profileImage = findViewById(R.id.profile_image_header);
         TextView username = findViewById(R.id.username);
         TextView githubLink = findViewById(R.id.github_url);
@@ -35,4 +42,24 @@ public class DetailsActivity extends AppCompatActivity {
                 .into(profileImage);
         githubLink.setText(devGithubLink);
     }
+
+    private Intent createShareIntent() {
+        StringBuilder shareMessage = new StringBuilder();
+        shareMessage.append(getString(R.string.share_part_message))
+                .append(devUsername).append(", ").append(devGithubLink);
+        return ShareCompat.IntentBuilder.from(this)
+                .setType(getString(R.string.share_intent_type))
+                .setText(shareMessage)
+                .getIntent();
+    }
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        MenuInflater menuInflater = getMenuInflater();
+        menuInflater.inflate(R.menu.share, menu);
+        MenuItem menuItem = menu.findItem(R.id.share_action_button);
+        menuItem.setIntent(createShareIntent());
+        return true;
+    }
+
 }

--- a/app/src/main/res/menu/share.xml
+++ b/app/src/main/res/menu/share.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".view.DetailsActivity">
+    <item
+        android:id="@+id/share_action_button"
+        android:icon="@drawable/abc_ic_menu_share_mtrl_alpha"
+        android:title="@string/share_details"
+        app:showAsAction="always"
+        tools:ignore="PrivateResource" />
+
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,7 @@
     <string name="username_text">Username</string>
     <string name="github_url_text">Github Link</string>
     <string name="details_name">Profile</string>
+    <string name="share_details">Share Profile</string>
+    <string name="share_intent_type">text/plain</string>
+    <string name="share_part_message">Check out this developer @</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?
Adds developer's profile share functionality

### Description of Task to be completed?

- [x] create menu resource directory
- [x] setup share.xml in menu directory to contain share icon for menu action bar
- [x] implement share functionality in DetailsActivity class when share icon is clicked

### How should this be manually tested?
```
Setup android studio
Clone repo in IDE
Build and run the application
Select a any developer to view their profile page
Click on the share icon at the right corner of the menu bar
```

Any background context you want to provide?

Nil

### What are the relevant pivotal tracker stories?

story type: feature
story Id: 156008359
story title: Share Functionality

### Screenshots (if appropriate)
![screenshot_1521645856](https://user-images.githubusercontent.com/22524619/37725230-ca75391a-2d32-11e8-9efc-f57c4638bfa4.png)
![screenshot_1521645875](https://user-images.githubusercontent.com/22524619/37725245-d546be40-2d32-11e8-8969-f07972a04884.png)
![screenshot_1521645916](https://user-images.githubusercontent.com/22524619/37725326-05619dfc-2d33-11e8-8263-0f87504128fb.png)


