### PR TITLE
feat(dev-location): Add dynamic functionality for selecting location and limit

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.andela.android.javadevelopers"
-        minSdkVersion 14
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,18 +12,20 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".view.MainActivity">
+        <activity android:name=".view.LocationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".view.MainActivity"/>
         <activity
             android:name=".view.DetailsActivity"
             android:label="@string/details_name"
-            android:theme="@style/ProfileTheme"
-            android:parentActivityName=".view.MainActivity">
+            android:parentActivityName=".view.MainActivity"
+            android:theme="@style/ProfileTheme">
+
             <!-- The meta-data tag is required if you support API level 15 and lower -->
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/andela/android/javadevelopers/presenter/DeveloperPresenter.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/presenter/DeveloperPresenter.java
@@ -40,12 +40,18 @@ public class DeveloperPresenter {
     }
 
     /**
-     * Communicates with github service class to receive list of java developers
+     * Communicates with github service class to receive list of java developers.
+     *
+     * @param location - string representing selected city
+     * @param limit - string representing selected limit(number of developers to fetch)
      */
-    public void getDevelopers() {
+    public void getDevelopers(String location, String limit) {
+        String url = "search/users?q=language:java+location:"
+                + location + "&per_page=" + limit + "&sort=followers";
+
         developerService
             .getAPI()
-            .getDevelopersLists()
+            .getDevelopersLists(url)
             .enqueue(new Callback<DevelopersListResponse>() {
 
                 /**

--- a/app/src/main/java/com/andela/android/javadevelopers/service/DevelopersApi.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/service/DevelopersApi.java
@@ -4,12 +4,15 @@ import com.andela.android.javadevelopers.model.DevelopersListResponse;
 
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Url;
 
 /**
  * Created by chike on 12/03/2018.
  */
 
 public interface DevelopersApi {
-    @GET("search/users?q=language:java+location:nairobi&per_page=100&sort=followers")
-    Call<DevelopersListResponse> getDevelopersLists();
+    @GET
+    Call<DevelopersListResponse> getDevelopersLists(
+            @Url String url
+    );
 }

--- a/app/src/main/java/com/andela/android/javadevelopers/view/LocationActivity.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/view/LocationActivity.java
@@ -1,0 +1,99 @@
+package com.andela.android.javadevelopers.view;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.RequiresApi;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Spinner;
+
+import com.andela.android.javadevelopers.R;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public final class LocationActivity extends AppCompatActivity {
+    List<String> listOfCities = new ArrayList<>();
+    List<String> listOfLimit = new ArrayList<>();
+
+    public static String city, limit;
+
+    Button findDevelopersButton;
+    Intent intent;
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_location);
+
+        intent = new Intent(this, MainActivity.class);
+
+        findDevelopersButton = findViewById(R.id.button);
+
+        findDevelopersButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                intent
+                        .putExtra("city", city)
+                        .putExtra("limit", limit);
+                startActivity(intent);
+            }
+        });
+
+        setUpSpinner(R.id.spinner_city, listOfCities, "city", "lagos", "nairobi", "kampala");
+        setUpSpinner(R.id.spinner_limit, listOfLimit, "limit", "10", "50", "100");
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    private void setUpSpinner(
+            int id, List<String> spinnerDropdown,
+            final String selectedSpinner,
+            String... elements) {
+
+        Spinner spinner = findViewById(id);
+
+        spinnerDropdown.addAll(Arrays.asList(elements));
+
+        // Creating adapter for spinner
+        ArrayAdapter<String> dataAdapter =
+                new ArrayAdapter<>(this, android.R.layout.simple_spinner_item, spinnerDropdown);
+
+        // Drop down layout style - list view with radio button
+        dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+
+        spinner.setElevation(5);
+
+        // attaching data adapter to spinner
+        spinner.setAdapter(dataAdapter);
+
+        // attaching onItemSelected listener
+        spinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                String selectedItem = parent.getItemAtPosition(position).toString();
+
+                switch (selectedSpinner) {
+                    case "city":
+                        city = selectedItem;
+                        break;
+                    case "limit":
+                        limit = selectedItem;
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+                // TODO Auto-generated method stub
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/andela/android/javadevelopers/view/MainActivity.java
+++ b/app/src/main/java/com/andela/android/javadevelopers/view/MainActivity.java
@@ -1,6 +1,7 @@
 package com.andela.android.javadevelopers.view;
 
 import android.app.ProgressDialog;
+import android.content.Intent;
 import android.graphics.Color;
 import android.support.design.widget.Snackbar;
 import android.support.v4.widget.SwipeRefreshLayout;
@@ -39,6 +40,8 @@ public class MainActivity extends AppCompatActivity implements DeveloperPresente
     ProgressDialog progressDialog;
     SwipeRefreshLayout swipeRefreshLayout;
 
+    String location, limit;
+
     /**
      * Called upon start of application
      *
@@ -50,6 +53,11 @@ public class MainActivity extends AppCompatActivity implements DeveloperPresente
         setContentView(R.layout.activity_main);
 
         setSwipeRefreshLayout();
+
+        Intent intent = getIntent();
+        location = intent.getStringExtra("city");
+        limit = intent.getStringExtra("limit");
+
 
         cnc = new CheckNetworkConnection(this);
         isConnected = cnc.getConnectivityStatus();
@@ -160,11 +168,12 @@ public class MainActivity extends AppCompatActivity implements DeveloperPresente
      * @param swipeRefreshLayout - layout containing list of developers
      */
     public void queryApi(SwipeRefreshLayout swipeRefreshLayout) {
+         String title = String.format("%s java developers", location);
         if (!swipeRefreshLayout.isRefreshing()) {
-            progressDialog = ProgressDialog.show(this, "Kenya Java Developers",
+            progressDialog = ProgressDialog.show(this, title,
                     "Loading... Please wait!!!", false, false);
         }
-            developerPresenter.getDevelopers();
+            developerPresenter.getDevelopers(location, limit);
     }
 
     /**

--- a/app/src/main/res/layout/activity_location.xml
+++ b/app/src/main/res/layout/activity_location.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".view.LocationActivity"
+    tools:layout_editor_absoluteY="81dp">
+
+    <Spinner
+        android:id="@+id/spinner_city"
+        android:layout_width="169dp"
+        android:layout_height="29dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="84dp"
+        android:prompt="@string/spinner_city_title"
+        app:layout_constraintStart_toEndOf="@+id/textView2"
+        app:layout_constraintTop_toBottomOf="@+id/textView" />
+
+    <Spinner
+        android:id="@+id/spinner_limit"
+        android:layout_width="128dp"
+        android:layout_height="29dp"
+        android:layout_marginStart="4dp"
+        android:layout_marginTop="36dp"
+        android:prompt="@string/spinner_limit_title"
+        app:layout_constraintStart_toEndOf="@+id/textView3"
+        app:layout_constraintTop_toBottomOf="@+id/spinner_city" />
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="333dp"
+        android:layout_height="37dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="28dp"
+        android:text="@string/layout_header"
+        android:textSize="25sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.514"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/button"
+        android:layout_width="226dp"
+        android:layout_height="69dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="116dp"
+        android:text="@string/find_button"
+        android:background="@color/colorPrimary"
+        android:textColor="@android:color/white"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/spinner_limit" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="117dp"
+        android:layout_height="29dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginTop="84dp"
+        android:fontFamily="sans-serif"
+        android:textSize="18sp"
+        android:text="@string/select_city"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/textView3"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView"
+        app:layout_constraintVertical_bias="0.0" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="124dp"
+        android:layout_height="28dp"
+        android:layout_marginBottom="116dp"
+        android:layout_marginStart="24dp"
+        android:fontFamily="sans-serif"
+        android:textSize="18sp"
+        android:text="@string/select_limit"
+        android:textStyle="bold"
+        app:layout_constraintBottom_toTopOf="@+id/button"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,4 +14,10 @@
     <string name="share_part_message">Check out this developer @</string>
     <string name="no_connection">No internet connection</string>
     <string name="fetch_failed">Bad internet Connection</string>
+    <string name="spinner_city_title">select city</string>
+    <string name="spinner_limit_title">select limit</string>
+    <string name="layout_header">Welcome To JavaDevelopers</string>
+    <string name="find_button">Find developers</string>
+    <string name="select_city">Select City:</string>
+    <string name="select_limit">Select Limit:</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?
Adds UI/Ux functionality for dynamically selecting location(city) and limit(number of fetched java developers)

### Description of Task to be completed?

- [x] create an activity for selecting location and limit
- [x] modify api and presenter classes to reflex these dynamism
- [x] modify MainActivity class to receive and dispatch intent strings

### How should this be manually tested?
```
Setup android studio
Clone repo in IDE
Build and run the application
Select a location and limit from the drop downs and click the Find Developers button.
```

Any background context you want to provide?

Nil

### What are the relevant pivotal tracker stories?

story type: feature
story Id: N/A
story title: A user should be able to select location and limit

### Screenshots (if appropriate)
![newjavadevs](https://user-images.githubusercontent.com/22524619/41412408-cc62ce26-6fd7-11e8-8d85-96a6f232855a.gif)
